### PR TITLE
Topic/2024.1/bug 34478 constructors design time

### DIFF
--- a/Metalama.Framework.DesignTime/Pipeline/AspectPipelineResult.cs
+++ b/Metalama.Framework.DesignTime/Pipeline/AspectPipelineResult.cs
@@ -482,7 +482,16 @@ namespace Metalama.Framework.DesignTime.Pipeline
                     continue;
                 }
 
-                var syntaxTree = targetSymbol.GetPrimarySyntaxReference().AssertNotNull().SyntaxTree;
+                var primarySyntaxReference = targetSymbol.GetPrimarySyntaxReference();
+
+                if ( primarySyntaxReference == null )
+                {
+                    // This is a transformation of an implicitly declared declaration that is implicitly declared even after syntax generator is executed.
+                    // E.g. appending parameters to implicit constructor of a non-partial type.
+                    continue;
+                }
+
+                var syntaxTree = primarySyntaxReference.SyntaxTree;
                 var filePath = syntaxTree.FilePath;
                 var builder = resultBuilders[filePath];
                 builder.Transformations ??= ImmutableArray.CreateBuilder<DesignTimeTransformation>();

--- a/Metalama.Framework.Engine/Linking/AspectLinker.cs
+++ b/Metalama.Framework.Engine/Linking/AspectLinker.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
-using Metalama.Framework.Engine.Observers;
 using Metalama.Framework.Engine.Services;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,9 +31,6 @@ namespace Metalama.Framework.Engine.Linking
             // First step. Adds all transformations to the compilation, resulting in intermediate compilation.
             var injectionStepOutput =
                 await new LinkerInjectionStep( this._serviceProvider, this._compilationContext ).ExecuteAsync( this._input, cancellationToken );
-
-            this._serviceProvider.GetService<ILinkerObserver>()
-                ?.OnIntermediateCompilationCreated( injectionStepOutput.IntermediateCompilation );
 
             // Second step. Count references to modified methods on semantic models of intermediate compilation and analyze method bodies.
             var analysisStepOutput =

--- a/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
+++ b/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
@@ -27,6 +27,8 @@ using MethodBase = Metalama.Framework.Engine.CodeModel.MethodBase;
 using RefKind = Metalama.Framework.Code.RefKind;
 using SpecialType = Metalama.Framework.Code.SpecialType;
 using TypedConstant = Metalama.Framework.Code.TypedConstant;
+using Metalama.Framework.Engine.Observers;
+
 
 #if DEBUG
 using Metalama.Framework.Engine.Formatting;
@@ -253,6 +255,9 @@ namespace Metalama.Framework.Engine.Linking
             transformations.Add( SyntaxTreeTransformation.AddTree( helperSyntaxTree ) );
 
             intermediateCompilation = intermediateCompilation.Update( transformations );
+
+            this._serviceProvider.GetService<ILinkerObserver>()
+                ?.OnIntermediateCompilationCreated( intermediateCompilation );
 
             var injectionRegistry = new LinkerInjectionRegistry(
                 transformationComparer,

--- a/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
+++ b/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Builders;
 using Metalama.Framework.Engine.Collections;
 using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Observers;
 using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Transformations;
@@ -27,8 +28,6 @@ using MethodBase = Metalama.Framework.Engine.CodeModel.MethodBase;
 using RefKind = Metalama.Framework.Code.RefKind;
 using SpecialType = Metalama.Framework.Code.SpecialType;
 using TypedConstant = Metalama.Framework.Code.TypedConstant;
-using Metalama.Framework.Engine.Observers;
-
 
 #if DEBUG
 using Metalama.Framework.Engine.Formatting;

--- a/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
+++ b/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
@@ -216,7 +216,9 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                         finalConstructor.GetSyntaxModifierList(),
                         Identifier( finalConstructor.DeclaringType.Name ),
                         syntaxGenerationContext.SyntaxGenerator.ParameterList( finalParameters, initialCompilationModel ),
-                        ConstructorInitializer(
+                        initialConstructor.IsImplicitlyDeclared
+                        ? default
+                        : ConstructorInitializer(
                             SyntaxKind.ThisConstructorInitializer,
                             ArgumentList(
                                 SeparatedList( 

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/DesignTime/IntroduceParameter_ImplicitParameterless.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/DesignTime/IntroduceParameter_ImplicitParameterless.t.cs
@@ -2,7 +2,7 @@ namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParame
 {
   partial class TestClass
   {
-    TestClass(global::System.Int32 introduced1 = 42, global::System.String introduced2 = "42") : this()
+    TestClass(global::System.Int32 introduced1 = 42, global::System.String introduced2 = "42")
     {
     }
   }

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Overrides/Constructors/Implicit.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Overrides/Constructors/Implicit.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Testing.AspectTesting;
+
+namespace Metalama.Framework.IntegrationTests.Aspects.Overrides.Constructors.Implicit
+{
+    // Tests single OverrideConstructor advice with trivial template on an implicit constructor.
+
+    public class OverrideAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            builder.Advice.Override(builder.Target.Constructors.Single(), nameof(Template));
+        }
+
+        [Template]
+        public void Template()
+        {
+            Console.WriteLine( "This is the override." );
+            meta.Proceed();
+        }
+    }
+
+    // <target>
+    [Override]
+    public class TargetClass
+    {
+    }
+}

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Overrides/Constructors/Implicit.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Overrides/Constructors/Implicit.t.cs
@@ -1,0 +1,8 @@
+[Override]
+public class TargetClass
+{
+  public TargetClass()
+  {
+    global::System.Console.WriteLine("This is the override.");
+  }
+}


### PR DESCRIPTION
#34486 Overriding implicitly declared constructor throws an exception.
#34484 Introduce parameter has invalid design time syntax for an implicit constructor.
#34478 SyntaxReference must not be not null in AspectPipelineResult.SplitResultsByTree.