### PR TITLE
#34467 Contracts on partial methods without implementation should not…

### DIFF
--- a/Metalama.Framework/Eligibility/EligibilityRuleFactory.cs
+++ b/Metalama.Framework/Eligibility/EligibilityRuleFactory.cs
@@ -6,6 +6,7 @@ using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 using Metalama.Framework.Eligibility.Implementation;
 using System;
+using System.Linq;
 
 namespace Metalama.Framework.Eligibility;
 
@@ -92,6 +93,10 @@ public static partial class EligibilityRuleFactory
             builder.DeclaringType().MustBeRunTimeOnly();
             builder.MustNotBeStatic();
             builder.MustNotBeRecordCopyConstructor();
+
+            builder.MustSatisfy(
+                c => c.Parameters.All( p => !p.IsParams ),
+                c => $"'{c}' must not have params parameter" );
         } );
 
     private static readonly IEligibilityRule<IDeclaration> _addInitializerRule = CreateRule<IDeclaration, IMemberOrNamedType>(

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/AppendParameter/Params.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/AppendParameter/Params.t.cs
@@ -1,13 +1,2 @@
-[MyAspect]
-public class C
-{
-  public C(global::System.Int32 ip1 = 13, global::System.Int32 ip2 = 42, params int[] p0)
-  {
-  }
-  public C(int p0, global::System.Int32 ip1 = 13, global::System.Int32 ip2 = 42, params string[] p1)
-  {
-  }
-  public C(int p0, int p1 = 0, global::System.Int32 ip1 = 13, global::System.Int32 ip2 = 42, params string[] p2)
-  {
-  }
-}
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0041 on `C`: `'Exception of type 'System.InvalidOperationException' thrown while executing BuildAspect for aspect [MyAspect] applied to 'C': Cannot add an IntroduceParameter advice to 'C.C(params int[])' because ''C.C(params int[])'' must not have params parameter. Check the IsAdviceEligible(AdviceKind.IntroduceParameter) method. Exception details are in '(none)'. To attach a debugger to the compiler, use the  '-p:MetalamaDebugCompiler=True' command-line option.`

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Contracts/Method_Partial_NoImpl.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Contracts/Method_Partial_NoImpl.t.cs
@@ -1,11 +1,2 @@
-internal partial class Target
-{
-  partial void M([NotNull] string m);
-  partial void M(string m)
-  {
-    if (m == null)
-    {
-      throw new global::System.ArgumentNullException("m");
-    }
-  }
-}
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0037 on `m`: `The aspect 'NotNull' cannot be applied to the parameter 'Target.M(string)/m' because 'the parent member 'Target.M(string)'' must not be partial without an implementation.`

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/DesignTime/IntroduceParameter_Params.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/DesignTime/IntroduceParameter_Params.t.cs
@@ -1,9 +1,1 @@
-namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_Params
-{
-  partial class TestClass
-  {
-    public TestClass(global::System.Int32 param1, global::System.Int32 introduced1 = 42, global::System.String introduced2 = "42", global::System.Int32[] param2) : this(param1, param2)
-    {
-    }
-  }
-}
+// Error LAMA0041 on `TestClass`: `'Exception of type 'System.InvalidOperationException' thrown while executing BuildAspect for aspect [IntroductionAttribute] applied to 'TestClass': Cannot add an IntroduceParameter advice to 'TestClass.TestClass(int, params int[])' because ''TestClass.TestClass(int, params int[])'' must not have params parameter. Check the IsAdviceEligible(AdviceKind.IntroduceParameter) method. Exception details are in '(none)'. To attach a debugger to the compiler, use the  '-p:MetalamaDebugCompiler=True' command-line option.`

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/DesignTime/IntroduceParameter_ParamsOptional.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/DesignTime/IntroduceParameter_ParamsOptional.t.cs
@@ -1,12 +1,1 @@
-namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_ParamsOptional
-{
-  partial class TestClass
-  {
-    public TestClass(global::System.Int32 param1, global::System.Int32 optParam = 42, global::System.Int32 introduced1 = 42, global::System.String introduced2 = "42", global::System.Int32[] param2) : this(param1, optParam: optParam, param2)
-    {
-    }
-    public TestClass(global::System.Int32 param1, global::System.Int32[] param2) : this(param1, param2, optParam: default)
-    {
-    }
-  }
-}
+// Error LAMA0041 on `TestClass`: `'Exception of type 'System.InvalidOperationException' thrown while executing BuildAspect for aspect [IntroductionAttribute] applied to 'TestClass': Cannot add an IntroduceParameter advice to 'TestClass.TestClass(int, int, params int[])' because ''TestClass.TestClass(int, int, params int[])'' must not have params parameter. Check the IsAdviceEligible(AdviceKind.IntroduceParameter) method. Exception details are in '(none)'. To attach a debugger to the compiler, use the  '-p:MetalamaDebugCompiler=True' command-line option.`


### PR DESCRIPTION
… be eligible.

#34477 Pulling dependencies: turn constructor with params parameter into eligibility error.