### PR TITLE
#3750 Improved diagnostics for missing Metalama using

### DIFF
--- a/Metalama.Framework.DesignTime/Preview/PreviewPipelineBasedService.cs
+++ b/Metalama.Framework.DesignTime/Preview/PreviewPipelineBasedService.cs
@@ -43,14 +43,14 @@ public abstract class PreviewPipelineBasedService
 
         if ( project == null )
         {
-            return (false, new[] { "The project has not been fully loaded yet." }, null, null, null);
+            return (false, ["The project has not been fully loaded yet."], null, null, null);
         }
 
         var compilation = await project.GetCompilationAsync( cancellationToken );
 
         if ( compilation == null )
         {
-            return (false, new[] { "The project has not been fully loaded yet." }, null, null, null);
+            return (false, ["The project has not been fully loaded yet."], null, null, null);
         }
 
         // Get the pipeline for the compilation.
@@ -58,7 +58,7 @@ public abstract class PreviewPipelineBasedService
 
         if ( pipeline == null )
         {
-            return (false, new[] { "The project has not been fully loaded yet." }, null, null, null);
+            return (false, ["The project has not been fully loaded yet."], null, null, null);
         }
 
         // Get a compilation _without_ generated code, and map the target symbol.
@@ -96,8 +96,7 @@ public abstract class PreviewPipelineBasedService
 
         if ( !getConfigurationResult.IsSuccessful )
         {
-            return (false, getConfigurationResult.Diagnostics.Where( d => d.Severity == DiagnosticSeverity.Error ).Select( d => d.ToString() ).ToArray(),
-                    null, null, null);
+            return (false, FormatErrors( getConfigurationResult.Diagnostics ), null, null, null);
         }
 
         var designTimeConfiguration = getConfigurationResult.Value;
@@ -107,7 +106,7 @@ public abstract class PreviewPipelineBasedService
 
         if ( !transitiveAspectManifest.IsSuccessful )
         {
-            return (false, transitiveAspectManifest.Diagnostics.Select( x => x.ToString() ).ToArray(), null, null, null);
+            return (false, FormatErrors( transitiveAspectManifest.Diagnostics ), null, null, null);
         }
 
         // For preview, we need to override a few options, especially to enable code formatting. We do this by replacing only the options
@@ -121,4 +120,7 @@ public abstract class PreviewPipelineBasedService
 
         return (true, null, previewServiceProvider, previewConfiguration, partialCompilation);
     }
+
+    protected static string[] FormatErrors( IEnumerable<Diagnostic> diagnostics )
+        => diagnostics.Where( d => d.Severity == DiagnosticSeverity.Error ).Select( d => d.ToString() ).ToArray();
 }

--- a/Metalama.Framework.DesignTime/Preview/TransformationPreviewServiceImpl.cs
+++ b/Metalama.Framework.DesignTime/Preview/TransformationPreviewServiceImpl.cs
@@ -8,7 +8,6 @@ using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Pipeline.DesignTime;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities.Threading;
-using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.DesignTime.Preview;
 
@@ -42,7 +41,7 @@ public sealed class TransformationPreviewServiceImpl : PreviewPipelineBasedServi
             preparation.Configuration!,
             cancellationToken );
 
-        var errorMessages = diagnostics.Where( d => d.Severity == DiagnosticSeverity.Error ).Select( d => d.ToString() ).ToArray();
+        var errorMessages = FormatErrors( diagnostics );
 
         if ( !pipelineResult.IsSuccessful || errorMessages.Length > 0 )
         {
@@ -51,7 +50,7 @@ public sealed class TransformationPreviewServiceImpl : PreviewPipelineBasedServi
 
         var transformedSyntaxTree = pipelineResult.Value.SyntaxTrees[syntaxTreeName];
 
-        return SerializablePreviewTransformationResult.Success( JsonSerializationHelper.CreateSerializableSyntaxTree( transformedSyntaxTree ), errorMessages );
+        return SerializablePreviewTransformationResult.Success( JsonSerializationHelper.CreateSerializableSyntaxTree( transformedSyntaxTree ), null );
     }
 
     Task<SerializablePreviewTransformationResult> ITransformationPreviewServiceImpl.PreviewTransformationAsync(

--- a/Metalama.Framework.Engine/Templating/TemplatingCodeValidator.Visitor.cs
+++ b/Metalama.Framework.Engine/Templating/TemplatingCodeValidator.Visitor.cs
@@ -728,7 +728,7 @@ namespace Metalama.Framework.Engine.Templating
 
                     this.Report(
                         TemplatingDiagnosticDescriptors.CompileTimeCodeNeedsNamespaceImport.CreateRoslynDiagnostic(
-                            declaredSymbol.GetDiagnosticLocation(),
+                            node.GetDiagnosticLocation(),
                             (declaredSymbol, CompileTimeCodeFastDetector.Namespace, attributeName) ) );
                 }
 


### PR DESCRIPTION
The errors were actually correct, so just small improvements:

1. Added missing filter for design-time errors (prevents warnings from polluting the gold bar message).
2. Report error on node, not symbol, so that the missing using error at compile-time shows on the correct file.