### PR TITLE
#35431 T#: typeof with non-trivial type used as a runtime expression …

### DIFF
--- a/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -2501,7 +2501,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                     ? this.WithCallToAddSimplifierAnnotation( this.Transform( nameExpression ) )
                     : nameExpression;
 
-                // Keep the annotations if this type is in the typeof expression. Creating runtime expression afterwards needs that.
+                // Keep the annotations if this type is in a typeof expression. Creating the runtime expression afterwards requires the annotation.
                 if ( node.Parent.IsKind( SyntaxKind.TypeOfExpression ) )
                 {
                     transformedNode = node.CopyAnnotationsTo( transformedNode );

--- a/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -2501,6 +2501,12 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                     ? this.WithCallToAddSimplifierAnnotation( this.Transform( nameExpression ) )
                     : nameExpression;
 
+                // Keep the annotations if this type is in the typeof expression. Creating runtime expression afterwards needs that.
+                if ( node.Parent.IsKind( SyntaxKind.TypeOfExpression ) )
+                {
+                    transformedNode = node.CopyAnnotationsTo( transformedNode );
+                }
+
                 return true;
 
             default:

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/InvalidCode/TemplateInvalidTypeOf.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/InvalidCode/TemplateInvalidTypeOf.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf;
+
+internal class Aspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var x1 = StaticCode.Foo(typeof(Object));
+        var x2 = StaticCode.Foo(typeof(System.Object));
+        var x3 = StaticCode.Foo(typeof(global::System.Object));
+        var x4 = StaticCode.Foo(typeof(ConcurrentQueue<int>));
+        var x5 = StaticCode.Foo(typeof(System.Collections.Concurrent.ConcurrentQueue<int>));
+        var x6 = StaticCode.Foo(typeof(global::System.Collections.Concurrent.ConcurrentQueue<int>));
+
+        return meta.Proceed();
+    }
+
+    [Template]
+    private int OtherTemplate([CompileTime] Type type)
+    {
+        return type.Name.Length;
+    }
+}
+
+internal class StaticCode
+{
+    public static int Foo(Type type) => type.FullName.Length;
+}
+
+internal class TargetCode
+{
+    // <target>
+    [Aspect]
+    private int Method(int a)
+    {
+        return a;
+    }
+}

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/InvalidCode/TemplateInvalidTypeOf.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/InvalidCode/TemplateInvalidTypeOf.t.cs
@@ -1,0 +1,11 @@
+[Aspect]
+private int Method(int a)
+{
+  var x1 = global::Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf.StaticCode.Foo(typeof(global::System.Object));
+  var x2 = global::Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf.StaticCode.Foo(typeof(global::System.Object));
+  var x3 = global::Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf.StaticCode.Foo(typeof(global::System.Object));
+  var x4 = global::Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf.StaticCode.Foo(typeof(global::System.Collections.Concurrent.ConcurrentQueue<global::System.Int32>));
+  var x5 = global::Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf.StaticCode.Foo(typeof(global::System.Collections.Concurrent.ConcurrentQueue<global::System.Int32>));
+  var x6 = global::Metalama.Framework.Tests.PublicPipeline.Aspects.InvalidCode.TemplateInvalidTypeOf.StaticCode.Foo(typeof(global::System.Collections.Concurrent.ConcurrentQueue<global::System.Int32>));
+  return a;
+}


### PR DESCRIPTION
…causes an assertion failure.