### PR TITLE
#35558 Promoted fields declared in non-primary syntax tree cannot be …

### DIFF
--- a/Metalama.Framework.Engine/CodeModel/Builders/BuiltProperty.cs
+++ b/Metalama.Framework.Engine/CodeModel/Builders/BuiltProperty.cs
@@ -5,6 +5,7 @@ using Metalama.Framework.Code.Invokers;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Utilities;
 using Metalama.Framework.RunTime;
+using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -22,6 +23,13 @@ internal sealed class BuiltProperty : BuiltPropertyOrIndexer, IPropertyImpl
     public IProperty? OverriddenProperty => this.Compilation.Factory.GetDeclaration( this.PropertyBuilder.OverriddenProperty );
 
     IProperty IProperty.Definition => this;
+
+    public override SyntaxTree? PrimarySyntaxTree =>
+        this.Builder switch
+        {
+            PromotedField promotedField => promotedField.Field.PrimarySyntaxTree,
+            _ => base.PrimarySyntaxTree,
+        };
 
     // TODO: When an interface is introduced, explicit implementation should appear here.
     [Memo]

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug34583.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug34583.cs
@@ -6,7 +6,7 @@
 
 using System;
 
-namespace Metalama.Framework.Tests.Integration.Tests.Aspects.Bugs.Bug33813;
+namespace Metalama.Framework.Tests.Integration.Tests.Aspects.Bugs.Bug34583;
 
 public class MyAttribute : Attribute
 {

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug35558.0.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug35558.0.cs
@@ -1,0 +1,7 @@
+namespace Metalama.Framework.Tests.Integration.Tests.Aspects.Bugs.Bug35558;
+
+// <target>
+public partial class TargetClass
+{
+    private int _field2;
+}

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug35558.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug35558.cs
@@ -1,0 +1,41 @@
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.Integration.Tests.Aspects.Bugs.Bug35558;
+
+public class TestAspect : TypeAspect
+{
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        foreach(var field in builder.Target.Fields)
+        {
+            // First override promoted
+            var result = builder.Advice.Override(field, nameof(PropertyTemplate));
+            builder.Advice.Override(result.Declaration, nameof(PropertyTemplate));
+        }
+    }
+
+    [Template]
+    public dynamic? PropertyTemplate
+    {
+        get
+        {
+            Console.WriteLine("Aspect");
+            return meta.Proceed();
+        }
+
+        set
+        {
+            Console.WriteLine("Aspect");
+            meta.Proceed();
+        }
+    }
+}
+
+// <target>
+[TestAspect]
+public partial class TargetClass
+{
+    private int _field1;
+}

--- a/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug35558.t.cs
+++ b/tests/Metalama.Framework.Tests.Integration/Tests/Aspects/Bugs/Bug35558.t.cs
@@ -1,0 +1,20 @@
+[TestAspect]
+public partial class TargetClass
+{
+  private global::System.Int32 _field11;
+  private global::System.Int32 _field1
+  {
+    get
+    {
+      global::System.Console.WriteLine("Aspect");
+      global::System.Console.WriteLine("Aspect");
+      return this._field11;
+    }
+    set
+    {
+      global::System.Console.WriteLine("Aspect");
+      global::System.Console.WriteLine("Aspect");
+      this._field11 = value;
+    }
+  }
+}


### PR DESCRIPTION
…overridden after being promoted.